### PR TITLE
Docker compose file selector syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,42 @@ Tail the logs of a specific docker compose service in a project:
 vfd logs --services=authentication-gw authgw -f
 ```
 
+#### Configuration
+
+The `vfd` script can be configured with a `settings.json` file located in the `vfd-tools` root directory. 
+
+The following settings are available:
+
+- profiles - a list of service profiles known to the script
+  - services - a list of services known to the profile
+    - syntax: `service[:docker-compose-file.yml, compose-service1, service2]`
+- dockerComposeOverrides - undocumented docker-compose file override configurations
+
+example:
+
+```
+"profiles": [
+    {
+      "name": "mvp",
+      "services": [
+          "virtual-finland:docker-compose.mvp-dev.yml",
+          "codesets:codesets,escoApi",  
+          "users-api"
+       ]
+    },
+]
+```
+
+explanation:
+
+- in profile "mvp", services:
+  - "virtual-finland" is defined in "docker-compose.mvp-dev.yml" file
+    - only one yml-file can be specified and it must be the first item in the comma separated list
+  - "codesets" is defined in the default "docker-compose.yml" file
+    - from the docker compose file, only the "codesets" and "escoApi" services will be brought up
+  - "users-api" is defined in the default "docker-compose.yml" file
+
+
 ## Traefik setup
 
 By default the `vfd` -script will use [traefik](https://github.com/traefik/traefik) as a reverse proxy for the services. For example, the `access-to-finland-demo-front` service will be available at `http://app-access-to-finland-demo-front.localhost` after bringing up the services.

--- a/settings.json
+++ b/settings.json
@@ -16,6 +16,10 @@
       ]
     },
     {
+      "name": "mvp",
+      "services": ["virtual-finland:docker-compose.mvp-dev.yml", "codesets", "users-api"]
+    },
+    {
       "name": "virtual-finland",
       "services": ["authentication-gw", "testbed-api", "virtual-finland", "codesets", "prh-mock", "users-api"]
     },

--- a/src/runner/commander/docker_compose.rs
+++ b/src/runner/commander/docker_compose.rs
@@ -13,14 +13,14 @@ pub fn run_action(settings: &Settings, service: &str, command: &str) {
         if settings
             .docker_compose_overrides
             .always_rebuild
-            .contains(&service_actual.to_string())
+            .contains(&service_actual)
             && !command.contains("--build")
         {
             command_actual = format!("{} --build", command);
         }
 
         environment_variables_mapping =
-            resolve_environment_values_mapping(settings, service_actual.as_str());
+            resolve_environment_values_mapping(settings, &service_actual);
     }
 
     let mut environment_variables_injection = String::new();

--- a/src/runner/commander/docker_compose.rs
+++ b/src/runner/commander/docker_compose.rs
@@ -7,7 +7,8 @@ pub fn run_action(settings: &Settings, service: &str, command: &str) {
     let formatted_runner_path = runner_app::format_runner_path(projects_root_path.clone());
     let mut command_actual = command.to_string();
     let mut environment_variables_mapping: Vec<(String, String)> = Vec::new();
-    let (service_actual, docker_compose_file) = resolve_service_and_docker_compose_file(service);
+    let (service_actual, docker_compose_file, docker_service_selections) =
+        resolve_service_and_docker_compose_file(service);
 
     if command.starts_with("up") {
         if settings
@@ -32,24 +33,34 @@ pub fn run_action(settings: &Settings, service: &str, command: &str) {
             );
         }
     }
+    let mut docker_service_selections_string = docker_service_selections.join(" ");
+    if !docker_service_selections_string.is_empty() {
+        docker_service_selections_string = format!(" {}", docker_service_selections_string);
+    }
 
     let mut print_compose_file_prefix = String::new();
     if docker_compose_file != "docker-compose.yml" {
         print_compose_file_prefix = format!("-f {} ", docker_compose_file);
     }
+
     println!(
-        "> {}{} → {}docker compose {}{}",
+        "> {}{} → {}docker compose {}{}{}",
         formatted_runner_path,
         service_actual,
         environment_variables_injection,
         print_compose_file_prefix,
-        command_actual
+        command_actual,
+        docker_service_selections_string
     );
 
     runner_app::run_command(
         &format!(
-            "docker compose -f {}/{}/{} {}",
-            projects_root_path, service_actual, docker_compose_file, command_actual
+            "docker compose -f {}/{}/{} {}{}",
+            projects_root_path,
+            service_actual,
+            docker_compose_file,
+            command_actual,
+            docker_service_selections_string
         ),
         false,
         Some(environment_variables_mapping),
@@ -148,19 +159,51 @@ pub fn resolve_service_exposed_infos(settings: &Settings, service: &str) -> Vec<
     hosts_with_service_ports
 }
 
-fn resolve_service_and_docker_compose_file(service: &str) -> (String, String) {
+fn resolve_service_and_docker_compose_file(service: &str) -> (String, String, Vec<String>) {
     let mut service_actual = service.to_string();
     let mut docker_compose_file = "docker-compose.yml".to_string();
+    let mut docker_service_names = Vec::<String>::new();
 
     if service.contains(':') {
         let service_parts: Vec<&str> = service.split(':').collect();
+
+        if service_parts.len() != 2 {
+            panic!("Invalid service format. Expected format: service[:docker-compose-file]");
+        }
+
         service_actual = service_parts[0].to_string();
-        docker_compose_file = service_parts[1].to_string();
+        let docker_compose_file_part = service_parts[1].to_string();
+        let docker_compose_file_parts: Vec<&str> = docker_compose_file_part
+            .split(',')
+            .map(|s| s.trim())
+            .collect();
+
+        // Service selection syntax validation
+        let docker_compose_file_parts_that_end_with_dot_yml = docker_compose_file_parts
+            .iter()
+            .filter(|s| s.ends_with(".yml"))
+            .collect::<Vec<&&str>>();
+        if !docker_compose_file_parts_that_end_with_dot_yml.is_empty() {
+            if docker_compose_file_parts_that_end_with_dot_yml.len() > 1 {
+                panic!("Invalid service format. Only 1 docker-compose file can be specified. Expected format: service[:docker-compose-file.yml, docker-compose-service1, service2 ...]");
+            }
+
+            if !docker_compose_file_parts[0].ends_with(".yml") {
+                panic!("Invalid service format. Expected format: service[:docker-compose-file.yml, docker-compose-service1, service2 ...]");
+            }
+        }
+
+        let mut services_index = 0;
+        if docker_compose_file_parts[0].ends_with(".yml") {
+            docker_compose_file = docker_compose_file_parts[0].to_string();
+            services_index = 1;
+        }
+
+        docker_service_names = docker_compose_file_parts[services_index..]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
     }
 
-    if !docker_compose_file.ends_with(".yml") {
-        panic!("docker-compose file must end with .yml");
-    }
-
-    (service_actual, docker_compose_file)
+    (service_actual, docker_compose_file, docker_service_names)
 }


### PR DESCRIPTION
Specify a docker-compose.yml-file for profile services by using appending the file name to the service name/folder: `my-service:my-docker-compose.yml`

eg.

```
"profiles": [
    {
      "name": "mvp",
      "services": [
          "virtual-finland:docker-compose.mvp-dev.yml",
          "codesets", 
          "users-api"
       ]
    },
]
```

Also specify the docker compose selected services by appending to the service[:service1, service2] -list.

example:

```
"profiles": [
    {
      "name": "mvp",
      "services": [
          "virtual-finland:docker-compose.mvp-dev.yml",
          "codesets:codesets,escoApi",  
          "users-api"
       ]
    },
]
```

explanation:

- in profile "mvp", services:
  - "virtual-finland" is defined in "docker-compose.mvp-dev.yml" file
    - only one yml-file can be specified and it must be the first item in the comma separated list
  - "codesets" is defined in the default "docker-compose.yml" file
    - from the docker compose file, only the "codesets" and "escoApi" services will be brought up
  - "users-api" is defined in the default "docker-compose.yml" file


