### PR TITLE
virtual-finland profile renamed to access-finland

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ vfd list
 Bring specific service profiles up:
 
 ```shell
-vfd up --profiles virtual-finland
+vfd up --profiles access-finland
 ```
 
 Bring specific services up:

--- a/settings.json
+++ b/settings.json
@@ -16,8 +16,8 @@
       ]
     },
     {
-      "name": "virtual-finland",
-      "services": ["authentication-gw", "testbed-api", "virtual-finland", "codesets", "prh-mock", "users-api"]
+      "name": "access-finland",
+      "services": ["authentication-gw", "testbed-api", "access-finland", "codesets", "prh-mock", "users-api"]
     },
     {
       "name": "virtual-finland-demo",


### PR DESCRIPTION
Nimesin tässä virtual-finland profiili -> acces-finland. Ei välttämätön, jos halutaan edelleen käyttää virtual-finland nimeä sisäisesti.